### PR TITLE
A címképre ELKELT!!! felirat került

### DIFF
--- a/elado/budapest-varkert/index.md
+++ b/elado/budapest-varkert/index.md
@@ -1,11 +1,11 @@
 ---
 layout: elado
-title: Budapesten a Világörökség része, a Várkert Palota eladó! 
+title: Budapesten a Világörökség része, a Várkert Palota **ELKELT!!!**! 
 
 # Irányára: 13000000 €
 ---
 
-#![](http://i.imgur.com/zhzPvJV.jpg) Budapesten a Világörökség része, a Várkert Palota eladó! 
+#![](http://i.imgur.com/zhzPvJV.jpg) Budapesten a Világörökség része, a Várkert Palota **ELKELT!!!**
 
 {% include fold.html %}
 


### PR DESCRIPTION
A címképre "ELKELT!!!" felirat került.
Ezt szeretném kitenni az /elado oldal listaképére is. Itt és a kikötőnél is.
Nem működik a kezdő oldal futó képe. Nem is látni, csak egy kettős keresztet. Nem is tudok belenyúlni, pedig a palotánál és a kikötőnél is kellene az ELKELT!!! felirat -  itt is.
Az összes hirdetés utolsó nagy képe helyett csak a normál méretű van, felette az oldalon is látható kettős kereszttel...
Köszönöm.
Már 35 éves és fél órás vagy! :) Isten éltessen!!!
